### PR TITLE
Add support to ignore test files in CheckProgram function

### DIFF
--- a/golangci/golangci.go
+++ b/golangci/golangci.go
@@ -2,6 +2,7 @@ package golangci
 
 import (
 	"regexp"
+	"strings"
 
 	"github.com/golangci/errcheck/internal/errcheck"
 	"golang.org/x/tools/go/loader"
@@ -62,7 +63,7 @@ func RunWithConfig(program *loader.Program, c *Config) ([]Issue, error) {
 
 	if err := checker.CheckProgram(program); err != nil {
 		if e, ok := err.(*errcheck.UncheckedErrors); ok {
-			return makeIssues(e), nil
+			return makeIssues(e, checker.WithoutTests), nil
 		}
 		if err == errcheck.ErrNoGoFiles {
 			return nil, nil
@@ -75,9 +76,12 @@ func RunWithConfig(program *loader.Program, c *Config) ([]Issue, error) {
 	return nil, nil
 }
 
-func makeIssues(e *errcheck.UncheckedErrors) []Issue {
+func makeIssues(e *errcheck.UncheckedErrors, withoutTests bool) []Issue {
 	var ret []Issue
 	for _, uncheckedError := range e.Errors {
+		if withoutTests && strings.Contains(uncheckedError.Pos.Filename, "_test.go") {
+			continue
+		}
 		ret = append(ret, Issue(uncheckedError))
 	}
 


### PR DESCRIPTION
`checker.CheckProgram(..` was removed from [kisielk/errcheck](https://github.comkisielk/errcheck). But golangci-lint still uses `checker.CheckProgram` instead of `checker.CheckPackages`.

checker.CheckPackages has support to ignore test because it loads the files using checker.load(), which [skips](https://github.com/golangci/errcheck/blob/46cecd339393da3e3742fc0045eb5e5ec0dd6563/internal/errcheck/errcheck.go#L155) the test files if needed

Add this hack until golangci/errcheck is rebased onto kisielk/errcheck. It will help solve golangci/golangci-lint#493